### PR TITLE
Added minVersion property to mixin

### DIFF
--- a/Common/src/main/resources/mavm.mixins.json
+++ b/Common/src/main/resources/mavm.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "io.github.akashiikun.mavm.mixin",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_17",
   "client": [
     "AxolotlEntityRendererMixin",


### PR DESCRIPTION
I added this property in order to fix this error:
```
[main/ERROR]: Mixin config forge-mavm.mixins.json does not specify "minVersion" property
```